### PR TITLE
Adaptions for running tirex on systemd

### DIFF
--- a/bin/tirex-backend-manager
+++ b/bin/tirex-backend-manager
@@ -55,7 +55,7 @@ die("refusing to run as root\n") if ($< == 0);
 my @argv = @ARGV;
 
 my %opts = ();
-GetOptions( \%opts, 'help|h', 'debug|d', 'config|c=s' ) or exit(2);
+GetOptions( \%opts, 'help|h', 'debug|d', 'foreground|f', 'config|c=s' ) or exit(2);
 
 if ($opts{'help'})
 {
@@ -67,6 +67,9 @@ if ($opts{'help'})
 }
 
 $Tirex::DEBUG = 1 if ($opts{'debug'});
+$Tirex::FOREGROUND = 1 if ($opts{'foreground'});
+# debug implies foreground
+$Tirex::FOREGROUND =1 if ($opts{'debug'});
 
 my $config_dir = $opts{'config'} || $Tirex::TIREX_CONFIGDIR;
 my $config_file = $config_dir . '/' . $Tirex::TIREX_CONFIGFILENAME;
@@ -84,10 +87,10 @@ syslog('info', 'tirex-backend-manager started with cmd line options: %s', join('
 Tirex::Config::dump_to_syslog();
 
 #-----------------------------------------------------------------------------
-# Daemonize unless in debug mode
+# Daemonize unless in debug mode or foreground
 #-----------------------------------------------------------------------------
 
-if (! $Tirex::DEBUG)
+if (!$Tirex::FOREGROUND)
 {
     chdir('/')                     or die("Cannot chdir to /: $!");
     open(STDIN,  '<', '/dev/null') or die("Cannot read from /dev/null: $!");
@@ -486,6 +489,10 @@ Display help message.
 =item B<-d>, B<--debug>
 
 Run in debug mode, and pass on the debug flag to workers
+
+=item B<-f>, B<--foreground>
+
+Run in foreground. E.g. when started from systemd service
 
 =item B<--config=DIR>
 

--- a/bin/tirex-master
+++ b/bin/tirex-master
@@ -60,7 +60,7 @@ die("refusing to run as root\n") if ($< == 0);
 my @argv = @ARGV;
 
 my %opts = ();
-GetOptions( \%opts, 'help|h', 'debug|d', 'config|c=s' ) or exit(2);
+GetOptions( \%opts, 'help|h', 'debug|d', 'foreground|f', 'config|c=s' ) or exit(2);
 
 if ($opts{'help'})
 {
@@ -72,6 +72,9 @@ if ($opts{'help'})
 }
 
 $Tirex::DEBUG = 1 if ($opts{'debug'});
+$Tirex::FOREGROUND = 1 if ($opts{'foreground'});
+# debug implies foreground
+$Tirex::FOREGROUND =1 if ($opts{'debug'});
 
 my $config_dir = $opts{'config'} || $Tirex::TIREX_CONFIGDIR;
 my $config_file = $config_dir . '/' . $Tirex::TIREX_CONFIGFILENAME;
@@ -134,9 +137,9 @@ if (Tirex::Config::get('sync_to_host')) {
 }
 
 #-----------------------------------------------------------------------------
-# Daemonize unless in debug mode
+# Daemonize unless in debug mode or foreground
 #-----------------------------------------------------------------------------
-if (!$Tirex::DEBUG)
+if (!$Tirex::FOREGROUND)
 {
     chdir('/')                     or die("Cannot chdir to /: $!");
     open(STDIN,  '<', '/dev/null') or die("Cannot read from /dev/null: $!");
@@ -586,6 +589,10 @@ Display help message.
 
 Run in debug mode. You'll see the actual messages sent and received and other
 debug messages.
+
+=item B<-f>, B<--foreground>
+
+Run in foreground. E.g. when started from systemd service
 
 =item B<-c>, B<--config=DIR>
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: tirex
 Section: web
 Priority: extra
 Maintainer: Frederik Ramm <frederik.ramm@geofabrik.de>
-Build-Depends: debhelper (>= 7), libboost-program-options-dev
+Build-Depends: debhelper (>= 7), libboost-program-options-dev, libmapnik-dev
 Homepage: http://wiki.openstreetmap.org/wiki/Tirex
 Standards-Version: 3.8.0
 

--- a/debian/tirex-backend-manager.service
+++ b/debian/tirex-backend-manager.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Backend of tirex rendering system
+After=network.target auditd.service
+Before=apache2.service tirex-master.service
+
+[Service]
+ExecStart=/usr/bin/tirex-backend-manager -f
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+User=tirex
+Group=tirex
+RuntimeDirectory=tirex
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/tirex-master.service
+++ b/debian/tirex-master.service
@@ -1,0 +1,15 @@
+Description=Master process of tirex rendering system
+After=network.target auditd.service
+Before=apache2.service
+
+[Service]
+ExecStart=/usr/bin/tirex-master -f
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+User=tirex
+Group=tirex
+RuntimeDirectory=tirex
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Starting from Debian 8 and Ubuntu LTS 16.04 these systems usually
run the systemd init-system.
To take advantage of this I added a commandline option for disabling daemon mode and
added two service-files for system startup.
