### PR TITLE
Provide checkerboard on full zoom range up to 20

### DIFF
--- a/etc/renderer/test/checkerboard.conf.dist
+++ b/etc/renderer/test/checkerboard.conf.dist
@@ -20,7 +20,7 @@ tiledir=/var/lib/tirex/tiles/test
 #minz=0
 
 #  maximum zoom level allowed (default 17)
-maxz=10
+maxz=20
 
 #-----------------------------------------------------------------------------
 #  Backend specific configuration


### PR DESCRIPTION
Some people missed this configuration and wondered why zoom 11 and greater returned no tiles. See #14. Providing checkerboard on full zoom scale sounds more helpful.