### PR TITLE
if configured, use stats_dir from config file

### DIFF
--- a/utils/tirex-create-stats-and-update-tiles.sh
+++ b/utils/tirex-create-stats-and-update-tiles.sh
@@ -67,7 +67,10 @@ exec >>/var/log/tirex/tirex-create-stats-and-update-tiles.log 2>&1
 [ -f /osm/update/osmupdate.lock ] && exit
 
 # directory where the statistics should go
-DIR=/var/lib/tirex/stats
+DIR=$(sed -n 's/^stats_dir=//p' /etc/tirex/tirex.conf)
+if [ -z "$DIR" ]; then
+  DIR=/var/lib/tirex/stats
+fi
 
 DATE=`date +%FT%H`
 


### PR DESCRIPTION
otherwise fall back to hard-coded /var/lib/tirex/stats

This allows #17