### PR TITLE
add build check with github actions

### DIFF
--- a/.github/workflows/build-with-ubuntu-20-04.yml
+++ b/.github/workflows/build-with-ubuntu-20-04.yml
@@ -1,0 +1,33 @@
+---
+name: Build with Ubuntu 20.04
+
+on:
+  pull_request:
+  push:
+
+env:
+  build-dependencies: >-
+    apache2-dev
+    libboost-program-options-dev
+    libmapnik-dev
+
+jobs:
+  build-and-test:
+    name: Build with Ubuntu 20.04
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install package(s)
+        run: sudo apt --yes install ${{ env.build-dependencies }}
+               apache2
+               libgd-gd2-perl
+               libjson-perl
+               libipc-sharelite-perl
+        shell: bash         
+      - name: Run `make`
+        run: make
+      - name: Run `make install`
+        run: sudo make install
+      - name: Run `make install-all`
+        run: sudo make install-all


### PR DESCRIPTION
This adds a very basic Continious Integration pipeline based on GitHub Actions, which is enabled in the "OpenStreetMap" group and the repositories under it, like this one of `tirex`. As discussed with the people of the OWG, there is no limit we run into, the checks might have to wait a bit, if some other checks are run within the group.

If this goes into the `master` branch, a basic check if `tirex` still builds is being run on each pull request or direct push to the repo.