### PR TITLE
adhere to FHS 3.0 for internal executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,11 @@ install: build
 	for program in bin/*; do \
 	    install -m 755 ${INSTALLOPTS} $$program $(DESTDIR)/usr/bin/; \
     done
-	install -m 755 ${INSTALLOPTS} -d                                       $(DESTDIR)/usr/lib/tirex/backends
-	install -m 755 ${INSTALLOPTS} backends/test                            $(DESTDIR)/usr/lib/tirex/backends
-	install -m 755 ${INSTALLOPTS} backends/wms                             $(DESTDIR)/usr/lib/tirex/backends
-	install -m 755 ${INSTALLOPTS} backends/tms                             $(DESTDIR)/usr/lib/tirex/backends
-	install -m 755 ${INSTALLOPTS} backends/mapserver                       $(DESTDIR)/usr/lib/tirex/backends
-	install -m 755 ${INSTALLOPTS} backends/openseamap                      $(DESTDIR)/usr/lib/tirex/backends
+	install -m 755 ${INSTALLOPTS} backends/test                            $(DESTDIR)/usr/libexec/tirex-backend-test
+	install -m 755 ${INSTALLOPTS} backends/wms                             $(DESTDIR)/usr/libexec/tirex-backend-wms
+	install -m 755 ${INSTALLOPTS} backends/tms                             $(DESTDIR)/usr/libexec/tirex-backend-tms
+	install -m 755 ${INSTALLOPTS} backends/mapserver                       $(DESTDIR)/usr/libexec/tirex-backend-mapserver
+	install -m 755 ${INSTALLOPTS} backends/openseamap                      $(DESTDIR)/usr/libexec/tirex-backend-openseamap
 	install -m 755 ${INSTALLOPTS} -d                                       $(DESTDIR)/etc/tirex
 	install -m 644 ${INSTALLOPTS} etc/tirex.conf.dist                      $(DESTDIR)/etc/tirex/tirex.conf
 	install -m 755 ${INSTALLOPTS} -d                                       $(DESTDIR)/etc/tirex/renderer

--- a/backend-mapnik/Makefile
+++ b/backend-mapnik/Makefile
@@ -11,5 +11,4 @@ clean:
 	rm -f backend-mapnik *.o
 
 install:
-	install -m 755 ${INSTALLOPTS} -d             $(DESTDIR)/usr/lib/tirex/backends/
-	install -m 755 ${INSTALLOPTS} backend-mapnik $(DESTDIR)/usr/lib/tirex/backends/mapnik
+	install -m 755 ${INSTALLOPTS} backend-mapnik $(DESTDIR)/usr/libexec/tirex-backend-mapnik

--- a/debian/tirex-backend-mapnik.install
+++ b/debian/tirex-backend-mapnik.install
@@ -1,2 +1,2 @@
-usr/lib/tirex/backends/mapnik
+usr/libexec/tirex-backend-mapnik
 etc/tirex/renderer/mapnik.conf

--- a/debian/tirex-backend-mapserver.install
+++ b/debian/tirex-backend-mapserver.install
@@ -1,4 +1,4 @@
-usr/lib/tirex/backends/mapserver
+usr/libexec/tirex-backend-mapserver
 usr/share/perl5/Tirex/Backend/Mapserver.pm
 usr/share/man/man3/Tirex::Backend::Mapserver.3pm
 etc/tirex/renderer/mapserver.conf

--- a/debian/tirex-backend-tms.install
+++ b/debian/tirex-backend-tms.install
@@ -1,4 +1,4 @@
-usr/lib/tirex/backends/tms
+usr/libexec/tirex-backend-tms
 usr/share/perl5/Tirex/Backend/TMS.pm
 usr/share/man/man3/Tirex::Backend::TMS.3pm
 etc/tirex/renderer/tms.conf

--- a/debian/tirex-backend-wms.install
+++ b/debian/tirex-backend-wms.install
@@ -1,4 +1,4 @@
-usr/lib/tirex/backends/wms
+usr/libexec/tirex-backend-wms
 usr/share/perl5/Tirex/Backend/WMS.pm
 usr/share/man/man3/Tirex::Backend::WMS.3pm
 etc/tirex/renderer/wms.conf

--- a/debian/tirex-core.install
+++ b/debian/tirex-core.install
@@ -22,4 +22,4 @@ etc/tirex/tirex.conf
 etc/tirex/renderer/test.conf
 etc/tirex/renderer/test/checkerboard.conf
 etc/logrotate.d/tirex-master
-usr/lib/tirex/backends/test
+usr/libexec/tirex-backend-test

--- a/debian/tirex-syncd.install
+++ b/debian/tirex-syncd.install
@@ -1,2 +1,2 @@
-/usr/bin/tirex-syncd
+/usr/libexec/tirex-syncd
 /usr/share/man/man1/tirex-syncd.1

--- a/etc/renderer/mapnik.conf.dist
+++ b/etc/renderer/mapnik.conf.dist
@@ -14,7 +14,7 @@
 name=mapnik
 
 #  path to executable of renderer
-path=/usr/lib/tirex/backends/mapnik
+path=/usr/libexec/tirex-backend-mapnik
 
 #  UDP port where the master can contact this renderer
 #  must be individual for each renderer

--- a/etc/renderer/mapserver.conf.dist
+++ b/etc/renderer/mapserver.conf.dist
@@ -14,7 +14,7 @@
 name=mapserver
 
 #  path to executable of renderer
-path=/usr/lib/tirex/backends/mapserver
+path=/usr/libexec/tirex-backend-mapserver
 
 #  UDP port where the master can contact this renderer
 #  must be individual for each renderer

--- a/etc/renderer/openseamap.conf.dist
+++ b/etc/renderer/openseamap.conf.dist
@@ -14,7 +14,7 @@
 name=openseamap
 
 #  path to executable of renderer
-path=/usr/lib/tirex/backends/openseamap
+path=/usr/libexec/tirex-backend-openseamap
 
 #  UDP port where the master can contact this renderer
 #  must be individual for each renderer

--- a/etc/renderer/test.conf.dist
+++ b/etc/renderer/test.conf.dist
@@ -14,7 +14,7 @@
 name=test
 
 #  path to executable of renderer
-path=/usr/lib/tirex/backends/test
+path=/usr/libexec/tirex-backend-test
 
 #  UDP port where the master can contact this renderer
 #  must be individual for each renderer

--- a/etc/renderer/tms.conf.dist
+++ b/etc/renderer/tms.conf.dist
@@ -14,7 +14,7 @@
 name=tms
 
 #  path to executable of renderer
-path=/usr/lib/tirex/backends/tms
+path=/usr/libexec/tirex-backend-tms
 
 #  UDP port where the master can contact this renderer
 #  must be individual for each renderer

--- a/etc/renderer/wms.conf.dist
+++ b/etc/renderer/wms.conf.dist
@@ -14,7 +14,7 @@
 name=wms
 
 #  path to executable of renderer
-path=/usr/lib/tirex/backends/wms
+path=/usr/libexec/tirex-backend-wms
 
 #  UDP port where the master can contact this renderer
 #  must be individual for each renderer

--- a/t/renderer.conf
+++ b/t/renderer.conf
@@ -3,7 +3,7 @@
 #
 
 name=mapnik2 # comment
-path=/usr/lib/tirex/backends/mapnik
+path=/usr/libexec/tirex-backend-mapnik
 port=1234
 procs=3
 

--- a/t/renderer_basic.t
+++ b/t/renderer_basic.t
@@ -18,16 +18,16 @@ use Tirex::Renderer;
 
 eval { Tirex::Renderer->new(                                                                           ); }; ($@ =~ qr{missing name} ) ? pass() : fail();
 eval { Tirex::Renderer->new( name => 'mapnik1',                                                        ); }; ($@ =~ qr{missing path} ) ? pass() : fail();
-eval { Tirex::Renderer->new( name => 'mapnik1', path => '/usr/lib/tirex/backends/mapnik'               ); }; ($@ =~ qr{missing port} ) ? pass() : fail();
-eval { Tirex::Renderer->new( name => 'mapnik1', path => '/usr/lib/tirex/backends/mapnik', port => 1234 ); }; ($@ =~ qr{missing procs}) ? pass() : fail();
+eval { Tirex::Renderer->new( name => 'mapnik1', path => '/usr/libexec/tirex-backend-mapnik'               ); }; ($@ =~ qr{missing port} ) ? pass() : fail();
+eval { Tirex::Renderer->new( name => 'mapnik1', path => '/usr/libexec/tirex-backend-mapnik', port => 1234 ); }; ($@ =~ qr{missing procs}) ? pass() : fail();
 
 is(Tirex::Renderer->get('mapnik1'), undef, 'get');
 
-my $r1 = Tirex::Renderer->new( name => 'mapnik1', path => '/usr/lib/tirex/backends/mapnik', port => 1234, procs => 3, fontdir => '/usr/lib/mapnik/fonts', fontdir_recurse => 0, plugindir => '/usr/lib/mapnik/input' );
+my $r1 = Tirex::Renderer->new( name => 'mapnik1', path => '/usr/libexec/tirex-backend-mapnik', port => 1234, procs => 3, fontdir => '/usr/lib/mapnik/fonts', fontdir_recurse => 0, plugindir => '/usr/lib/mapnik/input' );
 
 isa_ok($r1, 'Tirex::Renderer', 'class');
 is($r1->get_name(), 'mapnik1', 'name');
-is($r1->get_path(), '/usr/lib/tirex/backends/mapnik', 'path');
+is($r1->get_path(), '/usr/libexec/tirex-backend-mapnik', 'path');
 is($r1->get_port(), 1234, 'port');
 is($r1->get_procs(), 3, 'procs');
 
@@ -51,7 +51,7 @@ is_deeply($r1->get_config(), {
     plugindir       => '/usr/lib/mapnik/input'
 }, 'config');
 
-is($r1->to_s(), 'Renderer mapnik1: port=1234 procs=3 path=/usr/lib/tirex/backends/mapnik syslog_facility=daemon debug=0 fontdir=/usr/lib/mapnik/fonts fontdir_recurse=0 plugindir=/usr/lib/mapnik/input', 'to_s');
+is($r1->to_s(), 'Renderer mapnik1: port=1234 procs=3 path=/usr/libexec/tirex-backend-mapnik syslog_facility=daemon debug=0 fontdir=/usr/lib/mapnik/fonts fontdir_recurse=0 plugindir=/usr/lib/mapnik/input', 'to_s');
 
 is(Tirex::Renderer->get('mapnik1'), $r1, 'get');
 is(Tirex::Renderer->get('foo'), undef, 'get');
@@ -59,7 +59,7 @@ is(Tirex::Renderer->get('foo'), undef, 'get');
 is_deeply(Tirex::Renderer->status(), [
     {
         name            => 'mapnik1',
-        path            => '/usr/lib/tirex/backends/mapnik',
+        path            => '/usr/libexec/tirex-backend-mapnik',
         port            => 1234,
         procs           => 3,
         syslog_facility => 'daemon',
@@ -71,7 +71,7 @@ is_deeply(Tirex::Renderer->status(), [
     },
 ], 'status');
 
-eval { Tirex::Renderer->new( name => 'mapnik1', path => '/usr/lib/tirex/backends/mapnik', port => 1234, procs => 3, fontdir => '/usr/lib/mapnik/fonts', fontdir_recurse => 0, plugindir => '/usr/lib/mapnik/input' ); };
+eval { Tirex::Renderer->new( name => 'mapnik1', path => '/usr/libexec/tirex-backend-mapnik', port => 1234, procs => 3, fontdir => '/usr/lib/mapnik/fonts', fontdir_recurse => 0, plugindir => '/usr/lib/mapnik/input' ); };
 ($@ =~ qr{exists}) ? pass() : fail();
 
 eval { Tirex::Renderer->new_from_configfile('does not exist'); };
@@ -82,7 +82,7 @@ is(Tirex::Renderer->get('mapnik2'), $r3, 'get');
 
 isa_ok($r3, 'Tirex::Renderer', 'class');
 is($r3->get_name(), 'mapnik2', 'name');
-is($r3->get_path(), '/usr/lib/tirex/backends/mapnik', 'path');
+is($r3->get_path(), '/usr/libexec/tirex-backend-mapnik', 'path');
 is($r3->get_port(), 1234, 'port');
 is($r3->get_procs(), 3, 'procs');
 


### PR DESCRIPTION
This is meant to be a proposal, it hasn't been thoroughly tested. The [FHS 3.0](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html) describes /usr/libexec and encourages the use of that location for executables.