### PR TITLE
Fix simple pod syntax error for OpenSeaMap

### DIFF
--- a/lib/Tirex/Backend/OpenSeaMap.pm
+++ b/lib/Tirex/Backend/OpenSeaMap.pm
@@ -38,6 +38,8 @@ Config parameters for the map file:
 
 =item tilesize the tile size (should be 256 * scalefactor to avoid issues)
 
+=back
+
 =head1 METHODS
 
 =head2 $backend->init()


### PR DESCRIPTION
Currently `tirex` throws an error during compilation:

`lib/Tirex/Backend/OpenSeaMap.pm has 1 pod syntax error`

This PR fixes this.