### PR TITLE
Fix backend-mapnik build issue when CFLAGS being extended.

### DIFF
--- a/backend-mapnik/Makefile
+++ b/backend-mapnik/Makefile
@@ -1,6 +1,6 @@
 INSTALLOPTS=-g root -o root
 CFLAGS += -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
-CXXFLAGS = $(CFLAGS) `mapnik-config --cflags`
+CXXFLAGS = `mapnik-config --cflags` $(CFLAGS)
 CXXFLAGS += -Wall -Wextra -pedantic -Wredundant-decls -Wdisabled-optimization -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wold-style-cast
 LDFLAGS= `mapnik-config --libs --ldflags --dep-libs`
 


### PR DESCRIPTION
When extending CFLAGS (for regular [hardening](https://wiki.debian.org/Hardening)) the added `-g` doesn't have effect if `mapnik-config --cflags` is called afterwards. So changing the order slightly for this reason.