### PR TITLE
Make sure usr/libexec directory exists.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ install: build
 	for program in bin/*; do \
 	    install -m 755 ${INSTALLOPTS} $$program $(DESTDIR)/usr/bin/; \
     done
+	install -m 755 ${INSTALLOPTS} -d                                       $(DESTDIR)/usr/libexec
 	install -m 755 ${INSTALLOPTS} backends/test                            $(DESTDIR)/usr/libexec/tirex-backend-test
 	install -m 755 ${INSTALLOPTS} backends/wms                             $(DESTDIR)/usr/libexec/tirex-backend-wms
 	install -m 755 ${INSTALLOPTS} backends/tms                             $(DESTDIR)/usr/libexec/tirex-backend-tms


### PR DESCRIPTION
In some cases the directory doesn't exist at the moment of building. So making sure it gets created.