### PR TITLE
Dependency on boost::filesystem

### DIFF
--- a/backend-mapnik/Makefile
+++ b/backend-mapnik/Makefile
@@ -2,7 +2,7 @@ INSTALLOPTS=-g root -o root
 CFLAGS += -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 CXXFLAGS = `mapnik-config --cflags` $(CFLAGS)
 CXXFLAGS += -Wall -Wextra -pedantic -Wredundant-decls -Wdisabled-optimization -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wold-style-cast
-LDFLAGS= `mapnik-config --libs --ldflags --dep-libs`
+LDFLAGS= `mapnik-config --libs --ldflags --dep-libs` -lboost_filesystem
 
 backend-mapnik: renderd.o metatilehandler.o networklistener.o networkmessage.o networkrequest.o networkresponse.o debuggable.o requesthandler.o
 	$(CXX) -o $@ $^ $(LDFLAGS)

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Priority: optional
 Build-Depends: debhelper-compat (= 12),
                dh-apache2,
                libboost-program-options-dev,
+               libboost-filesystem-dev,
                libipc-sharelite-perl,
                libjson-perl,
                libmapnik-dev


### PR DESCRIPTION
boost::filesystem *was* a dependency of Mapnik. Because Mapnik does not depend on it any more, we have to declare the dependency ourselves.