### PR TITLE
Raise default master timeout from 10 to 60 mins.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 tirex (0.8.0-pre) unstable; urgency=medium
 
+  [ Frederik Ramm ]
   * preliminary build for github HEAD
+
+  [ Amanda McCann ]
+  * Default master timeout raised from 10 to 60 minutes
 
  -- Frederik Ramm <ramm@geofabrik.de>  Thu, 19 May 2022 13:41:14 +0200
 

--- a/debian/etc/tirex/tirex.conf
+++ b/debian/etc/tirex/tirex.conf
@@ -37,7 +37,7 @@ master_pidfile=/run/tirex/tirex-master.pid
 #  This must be larger than backend_manager_alive_timeout and should be larger than
 #  the rendering of any tile can need. Its only used to make sure that a
 #  rendering process that is long gone doesn't take up resources forever.
-#master_rendering_timeout=10
+#master_rendering_timeout=60
 
 #  Buckets for different priorities.
 bucket name=live       minprio=1  maxproc=4 maxload=20
@@ -57,4 +57,4 @@ backend_manager_pidfile=/run/tirex/tirex-backend-manager.pid
 #  If a rendering process doesn't send an alive message in this many minutes
 #  to the backend-manager, it will be killed by the manager. Make this smaller
 #  than master_rendering_timeout.
-#backend_manager_alive_timeout=8
+#backend_manager_alive_timeout=59

--- a/lib/Tirex.pm
+++ b/lib/Tirex.pm
@@ -65,11 +65,11 @@ our $SOCKET_DIR                      = '/run/tirex';
 our $MASTER_SYSLOG_FACILITY          = 'daemon';
 our $MASTER_PIDFILE                  = '/run/tirex/tirex-master.pid';
 our $MASTER_LOGFILE                  = '/var/log/tirex/jobs.log';
-our $MASTER_RENDERING_TIMEOUT        = 10; # minutes
+our $MASTER_RENDERING_TIMEOUT        = 60; # minutes
 
 our $BACKEND_MANAGER_SYSLOG_FACILITY = 'daemon';
 our $BACKEND_MANAGER_PIDFILE         = '/run/tirex/tirex-backend-manager.pid';
-our $BACKEND_MANAGER_ALIVE_TIMEOUT   = 8; # minutes - make this a tad smaller than the above
+our $BACKEND_MANAGER_ALIVE_TIMEOUT   = 59; # minutes - make this a tad smaller than the above
 
 our $SYNCD_PIDFILE                   = '/run/tirex/tirex-syncd.pid';
 our $SYNCD_UDP_PORT                  = 9323;


### PR DESCRIPTION
When rendering osm-carto, many large metatiles (e.g. z8) take >10min to render, hence I always change this value to 60min. So make that the default.