### PR TITLE
Fix unit tests. (The tests weren't updated to current output)

### DIFF
--- a/t/rendering_basic.t
+++ b/t/rendering_basic.t
@@ -103,6 +103,7 @@ my $expected_status = {
         count_error     => 0,
         count_rendered  => {},
         sum_render_time => {},
+        max_render_time => {},
     },
 };
 my $is_status = $rm->status();


### PR DESCRIPTION
They were first broken in bc64baf, with the addition of `mean_render_time`, but that was changed to `max_render_time` in da742d3 to `max_render_time`. This patch fixes the test.