### PR TITLE
change default mapnik fontdir_recurse to true

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ tirex (0.8.0-pre) unstable; urgency=medium
   [ Amanda McCann ]
   * Ensure tirex stats are initialized to 0 not null cf issue #29
   * Default master timeout raised from 10 to 60 minutes
+  * mapnik fontdir_recurse default changed to true
 
  -- Frederik Ramm <ramm@geofabrik.de>  Thu, 19 May 2022 13:41:14 +0200
 

--- a/backend-mapnik/renderd.cc
+++ b/backend-mapnik/renderd.cc
@@ -227,7 +227,7 @@ RenderDaemon::RenderDaemon(int argc, char **argv) :
 #endif
 
     tmp = getenv("TIREX_BACKEND_CFG_fontdir_recurse");
-    bool fr = tmp ? atoi(tmp) : false;
+    bool fr = tmp ? atoi(tmp) : true;
     tmp = getenv("TIREX_BACKEND_CFG_fontdir");
     if (tmp) loadFonts(tmp, fr);
 

--- a/debian/etc/tirex/renderer/mapnik.conf
+++ b/debian/etc/tirex/renderer/mapnik.conf
@@ -42,8 +42,8 @@ plugindir=/usr/share/tirex/mapnik/input
 #  throw an exception.
 fontdir=/usr/share/fonts/truetype
 
-#  Set this to 1 if you want fonts loaded recursively from directories
-#  inside the mapnik_fontdir directory. Defaults to 0.
-fontdir_recurse=1
+#  Set this to 0 if you don't want fonts loaded recursively from directories
+#  inside the mapnik_fontdir directory. Defaults to 1, meaning do recurse.
+#fontdir_recurse=1
 
 #-- THE END ------------------------------------------------------------------

--- a/etc/renderer/mapnik.conf.dist
+++ b/etc/renderer/mapnik.conf.dist
@@ -42,8 +42,8 @@ plugindir=/usr/lib/mapnik/3.0/input
 #  throw an exception.
 fontdir=/usr/lib/mapnik/fonts
 
-#  Set this to 1 if you want fonts loaded recursively from directories
-#  inside the mapnik_fontdir directory. Defaults to 0.
-#fontdir_recurse=0
+#  Set this to 0 if you don't want fonts loaded recursively from directories
+#  inside the mapnik_fontdir directory. Defaults to 1, meaning do recurse.
+#fontdir_recurse=1
 
 #-- THE END ------------------------------------------------------------------


### PR DESCRIPTION
Changes the default value of `fontdir_recurse` from false to true. (i.e. by default `tirex-backend-mapnik` will recurse through the font dir, unless the user turns that off). IME, this (recurse=true) is the common configuration, so I think that should be the default.

I am not 100% sure if this patch is correct, and ask for a review.