### PR TITLE
Fix mapnik for the example map (<Map bgcolor=) now.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ tirex (0.8.0-pre) unstable; urgency=medium
   * Ensure tirex stats are initialized to 0 not null cf issue #29
   * Default master timeout raised from 10 to 60 minutes
   * mapnik fontdir_recurse default changed to true
+  * Correct syntax in example map to match current mapnik API
 
  -- Frederik Ramm <ramm@geofabrik.de>  Thu, 19 May 2022 13:41:14 +0200
 

--- a/example-map/example.xml
+++ b/example-map/example.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map bgcolor="#eeebe2" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs +over">
+<Map background-color="#eeebe2" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs +over">
     <Style name="ocean">
         <Rule>
             <PolygonSymbolizer fill="#b1d2f5" />


### PR DESCRIPTION
Replace the `bgcolor=`, which was changed to `background-color=`, attribute in top level `<Map` element.
This was changed in mapnik 2+ cf:
https://github.com/mapnik/mapnik/wiki/Mapnik2_Changes#cssparameters----properties. This is a follow up from 17603aa, which did the first part, but I overlooked this necessary change.