### PR TITLE
Tirex-Backend-Manager should fail to start if a mapnik style cannot be loaded.

### DIFF
--- a/backend-mapnik/renderd.cc
+++ b/backend-mapnik/renderd.cc
@@ -238,7 +238,10 @@ RenderDaemon::RenderDaemon(int argc, char **argv) :
         char *tkn = strtok(dup, " ");
         while (tkn)
         {
-            loadMapnikWrapper(tkn);
+            if (!loadMapnikWrapper(tkn)) {
+                warning("Unable to load map");
+                exit(2);
+            }
             tkn = strtok(NULL, " ");
         }
     }

--- a/bin/tirex-backend-manager
+++ b/bin/tirex-backend-manager
@@ -55,7 +55,7 @@ die("refusing to run as root\n") if ($< == 0);
 my @argv = @ARGV;
 
 my %opts = ();
-GetOptions( \%opts, 'help|h', 'debug|d', 'foreground|f', 'config|c=s' ) or exit(2);
+GetOptions( \%opts, 'help|h', 'debug|d', 'foreground|f', 'config|c=s' ) or exit($Tirex::EXIT_CODE_INVALIDARGUMENT);
 
 if ($opts{'help'})
 {
@@ -375,7 +375,7 @@ sub cleanup_dead_workers
         {
             my $renderer = $workers->{$pid}->{'renderer'};
             syslog('err', 'terminating due to unexpected error in renderer %s', $renderer->get_name());
-            exit_gracefully(2);
+            exit_gracefully($Tirex::EXIT_CODE_INVALIDARGUMENT);
         }
 
         $workers->{$pid}->{'handle'}->close();

--- a/debian/tirex-backend-manager.service
+++ b/debian/tirex-backend-manager.service
@@ -9,6 +9,7 @@ ExecStart=/usr/bin/tirex-backend-manager -f
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
+RestartPreventExitStatus=INVALIDARGUMENT
 User=_tirex
 Group=_tirex
 

--- a/lib/Tirex.pm
+++ b/lib/Tirex.pm
@@ -44,6 +44,7 @@ our $MAX_PACKET_SIZE = 512;
 # max zoom level we will ever allow
 our $MAX_ZOOM = 30;
 
+our $EXIT_CODE_INVALIDARGUMENT = 2;
 our $EXIT_CODE_RESTART = 9;
 our $EXIT_CODE_DISABLE = 10;
 


### PR DESCRIPTION
If there is a problem initializing a map style, this patch will cause
the mapnik backend to exit (with 2). This causes the complete
tirex-backend-manager process to exit with 2. The previous behaviour was
for it to constantly attempt to initialize the map forevery

A mapnik style can fail to load for many reasons, such as missing
database tables. This change means incorrectly set up servers can be
detected quicker.