### PR TITLE
don't kill the whole backend manager when the OOM killer terminated o…

### DIFF
--- a/bin/tirex-backend-manager
+++ b/bin/tirex-backend-manager
@@ -374,8 +374,15 @@ sub cleanup_dead_workers
         if ($exit_code != $Tirex::EXIT_CODE_RESTART && ! defined $workers->{$pid}->{'hungup'})
         {
             my $renderer = $workers->{$pid}->{'renderer'};
-            syslog('err', 'terminating due to unexpected error in renderer %s', $renderer->get_name());
-            exit_gracefully($Tirex::EXIT_CODE_INVALIDARGUMENT);
+            if($signal == 9)
+            {
+              syslog('err', 'termination (OOM killer?) of renderer %s', $renderer->get_name());
+            }
+            else
+            {
+              syslog('err', 'terminating due to unexpected error in renderer %s', $renderer->get_name());
+              exit_gracefully($Tirex::EXIT_CODE_INVALIDARGUMENT);
+            }
         }
 
         $workers->{$pid}->{'handle'}->close();


### PR DESCRIPTION
…ne of out children

Seems newest mapnik has an issue on my system, but that tirex terminates as soon as that happens makes it worse.

Don't terminate the whole backend when mapnik goes memory-amok.